### PR TITLE
fix example1

### DIFF
--- a/test_example1.py
+++ b/test_example1.py
@@ -25,4 +25,4 @@ def test_example1_branch_verbose():
     _, _, _, branch_covered, branch_total, branch_missing = get_coverage(output)
     assert branch_covered == 1
     assert branch_total == 2
-    assert set(branch_missing) == {"3->1"}
+    assert set(branch_missing) == {"3->-1"}


### PR DESCRIPTION
coverage.py shows this output
"missing_branches": [
                [
                    3,
                    -1
                ]
            ]
It means that there is no coverage that doesn't enter if.

Full json output below
`
{
    "meta": {
        "format": 2,
        "version": "7.4.3",
        "timestamp": "2024-03-06T19:34:06.632000",
        "branch_coverage": true,
        "show_contexts": true
    },
    "files": {
        "examples/example1.py": {
            "executed_lines": [
                1,
                3,
                4
            ],
            "summary": {
                "covered_lines": 3,
                "num_statements": 3,
                "percent_covered": 80.0,
                "percent_covered_display": "80",
                "missing_lines": 0,
                "excluded_lines": 0,
                "num_branches": 2,
                "num_partial_branches": 1,
                "covered_branches": 1,
                "missing_branches": 1
            },
            "missing_lines": [],
            "excluded_lines": [],
            "contexts": {
                "1": [
                    ""
                ],
                "3": [
                    ""
                ],
                "4": [
                    ""
                ]
            },
            "executed_branches": [
                [
                    3,
                    4
                ]
            ],
            "missing_branches": [
                [
                    3,
                    -1
                ]
            ]
        }
    },
    "totals": {
        "covered_lines": 3,
        "num_statements": 3,
        "percent_covered": 80.0,
        "percent_covered_display": "80",
        "missing_lines": 0,
        "excluded_lines": 0,
        "num_branches": 2,
        "num_partial_branches": 1,
        "covered_branches": 1,
        "missing_branches": 1
    }
}
`