### PR TITLE
Remove statements plural from print_result

### DIFF
--- a/pcov.py
+++ b/pcov.py
@@ -10,7 +10,7 @@ def print_result(verbose:bool, stmt_covered:int, stmt_total:int, stmt_missing:li
 	branch_coverage = 0 if branch_total == 0 else branch_covered / branch_total * 100
 
 	print("=====================================")
-	print("Statements Coverage: {0:.2f} ({1}/{2})".format(stmt_coverage, stmt_covered, stmt_total))
+	print("Statement Coverage: {0:.2f} ({1}/{2})".format(stmt_coverage, stmt_covered, stmt_total))
 	if verbose:
 		print("Missing Statements: {}".format(", ".join([str(line_num) for line_num in stmt_missing])))
 	print("=====================================")


### PR DESCRIPTION
The provided `print_result` function prints `Statements Coverage:` while the [tests expect](https://github.com/coinse/cs453-assignment2-python-coverage/blob/386f2553fb169645631b3e40fef39abb37617a6f/test_pcov.py#L57) (and [README specifies](https://github.com/coinse/cs453-assignment2-python-coverage/blob/386f2553fb169645631b3e40fef39abb37617a6f/README.md?plain=1#L29)) `Statement Coverage:`.