### PR TITLE
Strip pcov output before parsing it

### DIFF
--- a/test_pcov.py
+++ b/test_pcov.py
@@ -43,7 +43,7 @@ def run_covpy(target, *args):
 	return stmt_covered, stmt_total, stmt_missing, branch_covered, branch_total, branch_missing
 
 def get_coverage(output):
-	lines = output.split("\n")
+	lines = output.strip().split("\n")
 	stmt_covered = 0
 	stmt_total = 0
 	stmt_missing = []


### PR DESCRIPTION
The pcov output contains a trailing newline (which is reasonable). When splitting the output on newlines in `get_coverage`, this produces an extra empty "line", causing the test to fail because the function later checks `line[0]`, producing an `IndexError`.
This change makes sure leading and trailing whitespace is stripped from the output before splitting and parsing it.