### PR TITLE
Make sure .split is not called on empty line numbers string

### DIFF
--- a/test_pcov.py
+++ b/test_pcov.py
@@ -63,9 +63,13 @@ def get_coverage(output):
 			branch_covered = int(nums.split("/")[0].strip())
 			branch_total = int(nums.split("/")[1].strip())
 		elif line.startswith("Missing Statements: "):
-			stmt_missing += line.split(": ")[1].split(", ")
+			linenos = line.split(": ")[1]
+			if linenos:
+				stmt_missing += linenos.split(", ")
 		elif line.startswith("Missing Branches: "):
-			branch_missing += line.split(": ")[1].split(", ")
+			linenos = line.split(": ")[1]
+			if linenos:
+				branch_missing += linenos.split(", ")
 	return stmt_covered, stmt_total, stmt_missing, branch_covered, branch_total, branch_missing
 
 if __name__ == '__main__':


### PR DESCRIPTION
Splitting an empty string with a specified separator returns `['']`. [docs](https://docs.python.org/3.3/library/stdtypes.html#str.split)

This breaks assertions for the number of missing statements/branches, because if `pcov` outputs just `Missing Statements: `, the resulting `missing_statements` list will contain a single empty string. The tests then assert that its length is 0, which does not hold even tough the output is correct.