### PR TITLE
Fix set item type in stmt_missing assertions

### DIFF
--- a/test_example2.py
+++ b/test_example2.py
@@ -11,7 +11,7 @@ def test_example2_statement_verbose():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 6
     assert stmt_total == 8
-    assert {7, 11} == set(stmt_missing)
+    assert {"7", "11"} == set(stmt_missing)
 
 def test_example2_branch():
     output = run_pcov("examples/example2.py", "10", "1")

--- a/test_example3.py
+++ b/test_example3.py
@@ -37,7 +37,7 @@ def test_example3_branch_1_verbose():
     _, _, _, branch_covered, branch_total, branch_missing = get_coverage(output)
     assert branch_covered == 3
     assert branch_total == 4
-    assert branch_missing == {"4->3"}
+    assert set(branch_missing) == {"4->3"}
 
 def test_example3_branch_2():
     output = run_pcov("examples/example3.py", "0")

--- a/test_example3.py
+++ b/test_example3.py
@@ -24,7 +24,7 @@ def test_example3_statement_2_verbose():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 2
     assert stmt_total == 4
-    assert set(stmt_missing) == {4, 5}
+    assert set(stmt_missing) == {"4", "5"}
 
 def test_example3_branch_1():
     output = run_pcov("examples/example3.py", "1")

--- a/test_example4.py
+++ b/test_example4.py
@@ -11,7 +11,7 @@ def test_example4_statement_verbose_1():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 7
     assert stmt_total == 22
-    assert stmt_missing == {"5", "6", "9", "12", "13", "14", "15", "16", "17", "18", "19", "24", "25", "26", "28"}
+    assert set(stmt_missing) == {"5", "6", "9", "12", "13", "14", "15", "16", "17", "18", "19", "24", "25", "26", "28"}
 
 def test_example4_branch_1():
     output = run_pcov("examples/example4.py")
@@ -37,7 +37,7 @@ def test_example4_statement_verbose_2():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 15
     assert stmt_total == 22
-    assert stmt_missing == {"14", "15", "16", "17", "18", "19", "26"}
+    assert set(stmt_missing) == {"14", "15", "16", "17", "18", "19", "26"}
 
 def test_example4_branch_2():
     output = run_pcov("examples/example4.py", "dog")
@@ -64,7 +64,7 @@ def test_example4_statement_verbose_3():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 17
     assert stmt_total == 22
-    assert stmt_missing == {"16", "17", "18", "19", "26"}
+    assert set(stmt_missing) == {"16", "17", "18", "19", "26"}
 
 def test_example4_branch_3():
     output = run_pcov("examples/example4.py", "dog", "cat")
@@ -90,7 +90,7 @@ def test_example4_statement_verbose_4():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 16
     assert stmt_total == 22
-    assert stmt_missing == {"14", "15", "16", "17", "18", "19"}
+    assert set(stmt_missing) == {"14", "15", "16", "17", "18", "19"}
 
 def test_example4_branch_4():
     output = run_pcov("examples/example4.py", "dog", "wolf", "cat")

--- a/test_example4.py
+++ b/test_example4.py
@@ -24,7 +24,7 @@ def test_example4_branch_verbose_1():
     _, _, _, branch_covered, branch_total, branch_missing = get_coverage(output)
     assert branch_covered == 1
     assert branch_total == 12
-    assert branch_missing == {'12->13', '12->14', '14->15', '14->16', '16->17', '16->18', '18->-11', '18->19', '23->24', '25->26', '25->28'}
+    assert set(branch_missing) == {'12->13', '12->14', '14->15', '14->16', '16->17', '16->18', '18->-11', '18->19', '23->24', '25->26', '25->28'}
 
 def test_example4_statement_2():
     output = run_pcov("examples/example4.py", "dog")
@@ -50,7 +50,7 @@ def test_example4_branch_verbose_2():
     _, _, _, branch_covered, branch_total, branch_missing = get_coverage(output)
     assert branch_covered == 4
     assert branch_total == 12
-    assert branch_missing == {'12->14', '14->15', '14->16', '16->17', '16->18', '18->-11', '18->19', '25->26'}
+    assert set(branch_missing) == {'12->14', '14->15', '14->16', '16->17', '16->18', '18->-11', '18->19', '25->26'}
 
 
 def test_example4_statement_3():
@@ -77,7 +77,7 @@ def test_example4_branch_verbose_3():
     _, _, _, branch_covered, branch_total, branch_missing = get_coverage(output)
     assert branch_covered == 6
     assert branch_total == 12
-    assert branch_missing == {'14->16', '16->17', '16->18', '18->-11', '18->19', '25->26'}
+    assert set(branch_missing) == {'14->16', '16->17', '16->18', '18->-11', '18->19', '25->26'}
 
 def test_example4_statement_4():
     output = run_pcov("examples/example4.py", "dog", "wolf", "cat")
@@ -103,6 +103,6 @@ def test_example4_branch_verbose_4():
     _, _, _, branch_covered, branch_total, branch_missing = get_coverage(output)
     assert branch_covered == 4
     assert branch_total == 12
-    assert branch_missing == {'12->14', '14->15', '14->16', '16->17', '16->18', '18->-11', '18->19', '23->-1'}
+    assert set(branch_missing) == {'12->14', '14->15', '14->16', '16->17', '16->18', '18->-11', '18->19', '23->-1'}
 
 

--- a/test_example4.py
+++ b/test_example4.py
@@ -11,7 +11,7 @@ def test_example4_statement_verbose_1():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 7
     assert stmt_total == 22
-    assert stmt_missing == {5, 6, 9, 12, 13, 14, 15, 16, 17, 18, 19, 24, 25, 26, 28}
+    assert stmt_missing == {"5", "6", "9", "12", "13", "14", "15", "16", "17", "18", "19", "24", "25", "26", "28"}
 
 def test_example4_branch_1():
     output = run_pcov("examples/example4.py")
@@ -37,7 +37,7 @@ def test_example4_statement_verbose_2():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 15
     assert stmt_total == 22
-    assert stmt_missing == {14, 15, 16, 17, 18, 19, 26}
+    assert stmt_missing == {"14", "15", "16", "17", "18", "19", "26"}
 
 def test_example4_branch_2():
     output = run_pcov("examples/example4.py", "dog")
@@ -64,7 +64,7 @@ def test_example4_statement_verbose_3():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 17
     assert stmt_total == 22
-    assert stmt_missing == {16, 17, 18, 19, 26}
+    assert stmt_missing == {"16", "17", "18", "19", "26"}
 
 def test_example4_branch_3():
     output = run_pcov("examples/example4.py", "dog", "cat")
@@ -90,7 +90,7 @@ def test_example4_statement_verbose_4():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 16
     assert stmt_total == 22
-    assert stmt_missing == {14, 15, 16, 17, 18, 19}
+    assert stmt_missing == {"14", "15", "16", "17", "18", "19"}
 
 def test_example4_branch_4():
     output = run_pcov("examples/example4.py", "dog", "wolf", "cat")

--- a/test_example5.py
+++ b/test_example5.py
@@ -24,7 +24,7 @@ def test_example5_branch_verbose_1():
     _, _, _, branch_covered, branch_total, branch_missing = get_coverage(output)
     assert branch_covered == 3
     assert branch_total == 6
-    assert branch_missing == {'6->7', '8->11', '12->13'}
+    assert set(branch_missing) == {'6->7', '8->11', '12->13'}
 
 def test_example5_statement_2():
     output = run_pcov("examples/example5.py", "0")
@@ -50,6 +50,6 @@ def test_example5_branch_verbose_2():
     _, _, _, branch_covered, branch_total, branch_missing = get_coverage(output)
     assert branch_covered == 2
     assert branch_total == 6
-    assert branch_missing == {'6->8', '8->9', '8->11', '12->14'}
+    assert set(branch_missing) == {'6->8', '8->9', '8->11', '12->14'}
 
 

--- a/test_example5.py
+++ b/test_example5.py
@@ -11,7 +11,7 @@ def test_example5_statement_verbose_1():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 11
     assert stmt_total == 14
-    assert stmt_missing == {7, 11, 13}
+    assert stmt_missing == {"7", "11", "13"}
 
 def test_example5_branch_1():
     output = run_pcov("examples/example5.py", "1")
@@ -37,7 +37,7 @@ def test_example5_statement_verbose_2():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 9
     assert stmt_total == 14
-    assert stmt_missing == {8, 9, 11, 14, 15}
+    assert stmt_missing == {"8", "9", "11", "14", "15"}
 
 def test_example5_branch_2():
     output = run_pcov("examples/example5.py", "0")

--- a/test_example5.py
+++ b/test_example5.py
@@ -11,7 +11,7 @@ def test_example5_statement_verbose_1():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 11
     assert stmt_total == 14
-    assert stmt_missing == {"7", "11", "13"}
+    assert set(stmt_missing) == {"7", "11", "13"}
 
 def test_example5_branch_1():
     output = run_pcov("examples/example5.py", "1")
@@ -37,7 +37,7 @@ def test_example5_statement_verbose_2():
     stmt_covered, stmt_total, stmt_missing, _, _, _ = get_coverage(output)
     assert stmt_covered == 9
     assert stmt_total == 14
-    assert stmt_missing == {"8", "9", "11", "14", "15"}
+    assert set(stmt_missing) == {"8", "9", "11", "14", "15"}
 
 def test_example5_branch_2():
     output = run_pcov("examples/example5.py", "0")


### PR DESCRIPTION
In [`test_pcov.generate_coverage`](https://github.com/coinse/cs453-assignment2-python-coverage/blob/fab18f385c7a52f4a66feb8c0b6e4f95ca8458ca/test_pcov.py#L68), line numbers of missing statements are parsed as strings, but the assertions in tests check the resulting sets against sets of integers. I also changed the assertions in test sets 4 and 5 to convert missed statement/branch lists to sets, in line with tests for examples 1/2.